### PR TITLE
add flags `default-pod-annotation` for e2e tests

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -125,6 +125,9 @@ type TestContextType struct {
 	// Indicates what path the kubernetes-anywhere is installed on
 	KubernetesAnywherePath string
 
+	// Indicates whether or not testing for sandbox containers.
+	EnableSandboxContainer bool
+
 	// Viper-only parameters.  These will in time replace all flags.
 
 	// Example: Create a file 'e2e.json' with the following:
@@ -234,6 +237,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
 	flag.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
 	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
+	flag.BoolVar(&TestContext.EnableSandboxContainer, "enable-sandbox-container", false, "whether or not testing for sandbox containers")
 }
 
 // Register flags specific to the cluster e2e test suite.

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -126,6 +126,7 @@ type TestContextType struct {
 	KubernetesAnywherePath string
 
 	// Annotations used for to test existing annotation based features, e.g. seccomp profile, sandbox container etc.
+	// Usage: --default-pod-annotation=k1=v1,k2=v2.
 	DefaultPodAnnotations map[string]string
 
 	// Viper-only parameters.  These will in time replace all flags.

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -125,8 +125,8 @@ type TestContextType struct {
 	// Indicates what path the kubernetes-anywhere is installed on
 	KubernetesAnywherePath string
 
-	// Indicates whether or not testing for sandbox containers.
-	EnableSandboxContainer bool
+	// Annotations used for to test existing annotation based features, e.g. seccomp profile, sandbox container etc.
+	DefaultPodAnnotations map[string]string
 
 	// Viper-only parameters.  These will in time replace all flags.
 
@@ -237,7 +237,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
 	flag.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
 	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
-	flag.BoolVar(&TestContext.EnableSandboxContainer, "enable-sandbox-container", false, "whether or not testing for sandbox containers")
+	flag.Var(utilflag.NewMapStringString(&TestContext.DefaultPodAnnotations), "default-pod-annotation", "A set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.")
 }
 
 // Register flags specific to the cluster e2e test suite.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -420,12 +420,15 @@ func RunIfContainerRuntimeIs(runtimes ...string) {
 	Skipf("Skipped because container runtime %q is not in %s", TestContext.ContainerRuntime, runtimes)
 }
 
-func InjectAnnotationIfSandboxContainerEnable(pod *v1.Pod) {
-	if !TestContext.EnableSandboxContainer {
+func InjectDefaultPodAnnotations(pod *v1.Pod) {
+	defaultPodAnnotations := TestContext.DefaultPodAnnotations
+	if len(defaultPodAnnotations) == 0 {
 		return
 	}
 	annotations := pod.GetObjectMeta().GetAnnotations()
-	annotations["io.kubernetes.cri.untrusted-workload"] = "true"
+	for k, v := range defaultPodAnnotations {
+		annotations[k] = v
+	}
 	pod.SetAnnotations(annotations)
 }
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -420,6 +420,15 @@ func RunIfContainerRuntimeIs(runtimes ...string) {
 	Skipf("Skipped because container runtime %q is not in %s", TestContext.ContainerRuntime, runtimes)
 }
 
+func InjectAnnotationIfSandboxContainerEnable(pod *v1.Pod) {
+	if !TestContext.EnableSandboxContainer {
+		return
+	}
+	annotations := pod.GetObjectMeta().GetAnnotations()
+	annotations["io.kubernetes.cri.untrusted-workload"] = "true"
+	pod.SetAnnotations(annotations)
+}
+
 func RunIfSystemSpecNameIs(names ...string) {
 	for _, name := range names {
 		if name == TestContext.SystemSpecName {

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -66,6 +66,8 @@ var _ = SIGDescribe("Events", func() {
 			},
 		}
 
+		framework.InjectAnnotationIfSandboxContainerEnable(pod)
+
 		By("submitting the pod to kubernetes")
 		defer func() {
 			By("deleting the pod")

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -66,7 +66,9 @@ var _ = SIGDescribe("Events", func() {
 			},
 		}
 
-		framework.InjectAnnotationIfSandboxContainerEnable(pod)
+		// Example for using DefaultPodAnnotation flag.
+		// TODO(erain): remove this when sending the upstream PR.
+		framework.InjectDefaultPodAnnotations(pod)
 
 		By("submitting the pod to kubernetes")
 		defer func() {

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -66,10 +66,6 @@ var _ = SIGDescribe("Events", func() {
 			},
 		}
 
-		// Example for using DefaultPodAnnotation flag.
-		// TODO(erain): remove this when sending the upstream PR.
-		framework.InjectDefaultPodAnnotations(pod)
-
 		By("submitting the pod to kubernetes")
 		defer func() {
 			By("deleting the pod")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

- New flag `default-pod-annotation ` in `TestContext` for e2e tests
- This flag represents a set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.
- For example, This flag will be useful for testing sandbox containers like kata and gvisor.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- New flag `default-pod-annotation ` in `TestContext` for e2e tests
```
