### PR TITLE
Test/cluster e2e conformance

### DIFF
--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -312,6 +312,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		rcName := "simpletest.rc"
 		uniqLabels := getUniqLabel("gctest", "delete_pods")
 		rc := newOwnerRC(f, rcName, 2, uniqLabels)
+		framework.InjectDefaultPodAnnotationsForReplicationController(rc)
 		By("create the rc")
 		rc, err := rcClient.Create(rc)
 		if err != nil {
@@ -370,6 +371,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		rcName := "simpletest.rc"
 		uniqLabels := getUniqLabel("gctest", "orphan_pods")
 		rc := newOwnerRC(f, rcName, estimateMaximumPods(clientSet, 10, 100), uniqLabels)
+		framework.InjectDefaultPodAnnotationsForReplicationController(rc)
 		By("create the rc")
 		rc, err := rcClient.Create(rc)
 		if err != nil {
@@ -485,6 +487,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		deploymentName := "simpletest.deployment"
 		uniqLabels := getUniqLabel("gctest", "delete_rs")
 		deployment := newOwnerDeployment(f, deploymentName, uniqLabels)
+		framework.InjectDefaultPodAnnotationsForDeployment(deployment)
 		By("create the deployment")
 		createdDeployment, err := deployClient.Create(deployment)
 		if err != nil {
@@ -544,6 +547,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		deploymentName := "simpletest.deployment"
 		uniqLabels := getUniqLabel("gctest", "orphan_rs")
 		deployment := newOwnerDeployment(f, deploymentName, uniqLabels)
+		framework.InjectDefaultPodAnnotationsForDeployment(deployment)
 		By("create the deployment")
 		createdDeployment, err := deployClient.Create(deployment)
 		if err != nil {
@@ -618,6 +622,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		rcName := "simpletest.rc"
 		uniqLabels := getUniqLabel("gctest", "delete_pods_foreground")
 		rc := newOwnerRC(f, rcName, estimateMaximumPods(clientSet, 10, 100), uniqLabels)
+		framework.InjectDefaultPodAnnotationsForReplicationController(rc)
 		By("create the rc")
 		rc, err := rcClient.Create(rc)
 		if err != nil {
@@ -708,6 +713,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		halfReplicas := int(replicas / 2)
 		uniqLabels_deleted := getUniqLabel("gctest_d", "valid_and_pending_owners_d")
 		rc1 := newOwnerRC(f, rc1Name, replicas, uniqLabels_deleted)
+		framework.InjectDefaultPodAnnotationsForReplicationController(rc1)
 		By("create the rc1")
 		rc1, err := rcClient.Create(rc1)
 		if err != nil {
@@ -716,6 +722,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		rc2Name := "simpletest-rc-to-stay"
 		uniqLabels_stay := getUniqLabel("gctest_s", "valid_and_pending_owners_s")
 		rc2 := newOwnerRC(f, rc2Name, 0, uniqLabels_stay)
+		framework.InjectDefaultPodAnnotationsForReplicationController(rc2)
 		By("create the rc2")
 		rc2, err = rcClient.Create(rc2)
 		if err != nil {
@@ -817,12 +824,15 @@ var _ = SIGDescribe("Garbage collector", func() {
 		clientSet := f.ClientSet
 		podClient := clientSet.CoreV1().Pods(f.Namespace.Name)
 		pod1 := newGCPod("pod1")
+		framework.InjectDefaultPodAnnotationsForPod(pod1)
 		pod1, err := podClient.Create(pod1)
 		Expect(err).NotTo(HaveOccurred())
 		pod2 := newGCPod("pod2")
+		framework.InjectDefaultPodAnnotationsForPod(pod2)
 		pod2, err = podClient.Create(pod2)
 		Expect(err).NotTo(HaveOccurred())
 		pod3 := newGCPod("pod3")
+		framework.InjectDefaultPodAnnotationsForPod(pod3)
 		pod3, err = podClient.Create(pod3)
 		Expect(err).NotTo(HaveOccurred())
 		// create circular dependency

--- a/test/e2e/apimachinery/watch.go
+++ b/test/e2e/apimachinery/watch.go
@@ -182,7 +182,7 @@ var _ = SIGDescribe("Watchers", func() {
 			observed by the previous watch, and it will continue delivering notifications from
 			that point in time.
 	*/
-	framework.ConformanceIt("should be able to restart watching from the last resource version observed by the previous watch", func() {
+	framework.ConformanceIt("should \be able to restart watching from the last resource version observed by the previous watch", func() {
 		c := f.ClientSet
 		ns := f.Namespace.Name
 

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -109,6 +109,7 @@ func TestReplicationControllerServeImageOrFail(f *framework.Framework, test stri
 	By(fmt.Sprintf("Creating replication controller %s", name))
 	newRC := newRC(name, replicas, map[string]string{"name": name}, name, image)
 	newRC.Spec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{{ContainerPort: 9376}}
+	framework.InjectDefaultPodAnnotationsForReplicationController(newRC)
 	_, err := f.ClientSet.CoreV1().ReplicationControllers(f.Namespace.Name).Create(newRC)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -722,6 +722,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					NodeName: node.Name,
 				},
 			}
+			framework.InjectDefaultPodAnnotationsForPod(pod)
 			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
 			framework.ExpectNoError(err)
 

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -223,6 +223,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 				RestartPolicy: v1.RestartPolicyNever,
 			},
 		}
+		framework.InjectDefaultPodAnnotationsForPod(pod)
 
 		pod.Spec.Containers = append(pod.Spec.Containers, v1.Container{
 			Name:  "namespace-test",
@@ -388,6 +389,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 					AutomountServiceAccountToken: tc.AutomountPodSpec,
 				},
 			}
+			framework.InjectDefaultPodAnnotationsForPod(pod)
 			createdPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
 			framework.ExpectNoError(err)
 			framework.Logf("created pod %s", tc.PodName)

--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -787,7 +787,7 @@ func NewStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 		})
 	}
 
-	return &apps.StatefulSet{
+	ss := &apps.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
 			APIVersion: "apps/v1",
@@ -822,6 +822,8 @@ func NewStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 			ServiceName:          governingSvcName,
 		},
 	}
+	InjectDefaultPodAnnotationsForStatefulSet(ss)
+	return ss
 }
 
 // NewStatefulSetScale creates a new StatefulSet scale subresource and returns it

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -238,7 +238,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
 	flag.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
 	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
-	flag.Var(utilflag.NewMapStringString(&TestContext.DefaultPodAnnotations), "default-pod-annotation", "A set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.")
+	flag.Var(utilflag.NewMapStringString(&TestContext.DefaultPodAnnotations), "default-pod-annotations", "A set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.")
 }
 
 // Register flags specific to the cluster e2e test suite.

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -125,6 +125,10 @@ type TestContextType struct {
 	// Indicates what path the kubernetes-anywhere is installed on
 	KubernetesAnywherePath string
 
+	// Annotations used for to test existing annotation based features, e.g. seccomp profile, sandbox container etc.
+	// Usage: --default-pod-annotation=k1=v1,k2=v2.
+	DefaultPodAnnotations map[string]string
+
 	// Viper-only parameters.  These will in time replace all flags.
 
 	// Example: Create a file 'e2e.json' with the following:
@@ -234,6 +238,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
 	flag.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
 	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
+	flag.Var(utilflag.NewMapStringString(&TestContext.DefaultPodAnnotations), "default-pod-annotation", "A set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.")
 }
 
 // Register flags specific to the cluster e2e test suite.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -420,6 +420,18 @@ func RunIfContainerRuntimeIs(runtimes ...string) {
 	Skipf("Skipped because container runtime %q is not in %s", TestContext.ContainerRuntime, runtimes)
 }
 
+func InjectDefaultPodAnnotations(pod *v1.Pod) {
+	defaultPodAnnotations := TestContext.DefaultPodAnnotations
+	if len(defaultPodAnnotations) == 0 {
+		return
+	}
+	annotations := pod.GetObjectMeta().GetAnnotations()
+	for k, v := range defaultPodAnnotations {
+		annotations[k] = v
+	}
+	pod.SetAnnotations(annotations)
+}
+
 func RunIfSystemSpecNameIs(names ...string) {
 	for _, name := range names {
 		if name == TestContext.SystemSpecName {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -56,6 +56,7 @@ import (
 	extensions "k8s.io/api/extensions/v1beta1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -420,7 +421,7 @@ func RunIfContainerRuntimeIs(runtimes ...string) {
 	Skipf("Skipped because container runtime %q is not in %s", TestContext.ContainerRuntime, runtimes)
 }
 
-func InjectDefaultPodAnnotations(pod *v1.Pod) {
+func InjectDefaultPodAnnotationsForPod(pod *v1.Pod) {
 	defaultPodAnnotations := TestContext.DefaultPodAnnotations
 	if len(defaultPodAnnotations) == 0 {
 		return
@@ -430,6 +431,42 @@ func InjectDefaultPodAnnotations(pod *v1.Pod) {
 		annotations[k] = v
 	}
 	pod.SetAnnotations(annotations)
+}
+
+func InjectDefaultPodAnnotationsForDeployment(deployment *v1beta1.Deployment) {
+	defaultPodAnnotations := TestContext.DefaultPodAnnotations
+	if len(defaultPodAnnotations) == 0 {
+		return
+	}
+	annotations := deployment.Spec.Template.GetAnnotations()
+	for k, v := range defaultPodAnnotations {
+		annotations[k] = v
+	}
+	deployment.Spec.Template.SetAnnotations(annotations)
+}
+
+func InjectDefaultPodAnnotationsForReplicationController(rc *v1.ReplicationController) {
+	defaultPodAnnotations := TestContext.DefaultPodAnnotations
+	if len(defaultPodAnnotations) == 0 {
+		return
+	}
+	annotations := rc.Spec.Template.GetAnnotations()
+	for k, v := range defaultPodAnnotations {
+		annotations[k] = v
+	}
+	rc.Spec.Template.SetAnnotations(annotations)
+}
+
+func InjectDefaultPodAnnotationsForStatefulSet(ss *apps.StatefulSet) {
+	defaultPodAnnotations := TestContext.DefaultPodAnnotations
+	if len(defaultPodAnnotations) == 0 {
+		return
+	}
+	annotations := ss.Spec.Template.GetAnnotations()
+	for k, v := range defaultPodAnnotations {
+		annotations[k] = v
+	}
+	ss.Spec.Template.SetAnnotations(annotations)
 }
 
 func RunIfSystemSpecNameIs(names ...string) {
@@ -3538,6 +3575,7 @@ func CreatePodOrFail(c clientset.Interface, ns, name string, labels map[string]s
 			},
 		},
 	}
+	InjectDefaultPodAnnotationsForPod(pod)
 	_, err := c.CoreV1().Pods(ns).Create(pod)
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/test/e2e/node/events.go
+++ b/test/e2e/node/events.go
@@ -66,6 +66,8 @@ var _ = SIGDescribe("Events", func() {
 			},
 		}
 
+		framework.InjectDefaultPodAnnotationsForPod(pod)
+
 		By("submitting the pod to kubernetes")
 		defer func() {
 			By("deleting the pod")

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -74,6 +74,8 @@ var _ = SIGDescribe("Pods Extended", func() {
 				},
 			}
 
+			framework.InjectDefaultPodAnnotationsForPod(pod)
+
 			By("setting up watch")
 			selector := labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 			options := metav1.ListOptions{LabelSelector: selector.String()}
@@ -238,6 +240,8 @@ var _ = SIGDescribe("Pods Extended", func() {
 					},
 				},
 			}
+
+			framework.InjectDefaultPodAnnotationsForPod(pod)
 
 			By("submitting the pod to kubernetes")
 			podClient.Create(pod)

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -53,6 +53,8 @@ func testPreStop(c clientset.Interface, ns string) {
 			},
 		},
 	}
+	framework.InjectDefaultPodAnnotationsForPod(podDescr)
+
 	By(fmt.Sprintf("Creating server pod %s in namespace %s", podDescr.Name, ns))
 	podDescr, err := c.CoreV1().Pods(ns).Create(podDescr)
 	framework.ExpectNoError(err, fmt.Sprintf("creating pod %s", podDescr.Name))
@@ -95,6 +97,7 @@ func testPreStop(c clientset.Interface, ns string) {
 			},
 		},
 	}
+	framework.InjectDefaultPodAnnotationsForPod(preStopDescr)
 
 	By(fmt.Sprintf("Creating tester pod %s in namespace %s", preStopDescr.Name, ns))
 	preStopDescr, err = c.CoreV1().Pods(ns).Create(preStopDescr)

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/test/e2e/framework"
 	"math"
 	"os"
 	"sync"
@@ -573,6 +574,7 @@ func (config *RCConfig) create() error {
 			},
 		},
 	}
+	framework.InjectDefaultPodAnnotationsForReplicationController(rc)
 
 	if len(config.SecretNames) > 0 {
 		attachSecrets(rc.Spec.Template, config.SecretNames)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

- New flag `default-pod-annotation` in `TestContext` for e2e tests. This flag represents a set of key=value pairs that describe annotations which are used for annotation-based features, e.g. seccomp profile, sandbox container etc.

- Modify existing e2e tests for injecting the `default-pod-annotation`, for internal testing purpose. 

